### PR TITLE
Fix for Kalman filter to also output trajectories of neighbours

### DIFF
--- a/trajnetbaselines/classical/kalman.py
+++ b/trajnetbaselines/classical/kalman.py
@@ -66,7 +66,6 @@ def predict(paths, predict_all=True, n_predict=12, obs_length=9):
             neighbours_tracks.append(np.array(predictions[1:]))
 
     ## Unimodal Ouput
-    neighbours_tracks = []
     if len(np.array(neighbours_tracks)):
         neighbours_tracks = np.array(neighbours_tracks).transpose(1, 0, 2)
 


### PR DESCRIPTION
## Summary
Minor but important fix in Kalman filter model, to also output trajectories of neighbours

## Content
The variable that contained the neighbour predictions (`neighbour_tracks` - see line 8 of the file that was changed for initialization) was being overwriten, and so those tracks ended up being lost. This PR involves removing the line in which the variable is overwritten.

## Effect
This was causing KF to only output trajectory of primary pedestrian, which made the computation of Col-I metric impossible. 

## Related PRs/Issues
This (partially) addresses #19.