### PR TITLE
fix when only one ped in scene

### DIFF
--- a/trajnetbaselines/lstm/gridbased_pooling.py
+++ b/trajnetbaselines/lstm/gridbased_pooling.py
@@ -250,7 +250,7 @@ class GridBasedPooling(torch.nn.Module):
 
         ## if only primary pedestrian present
         if num_tracks == 1:
-            return self.constant*torch.ones(1, self.pooling_dim, self.n, self.n, device=obs.device)
+            return self.constant*torch.ones(batch_size, self.pooling_dim, self.n, self.n, device=obs.device)
 
         ## Get relative position
         ## [batch_size, num_tracks, 2] --> [batch_size, num_tracks, num_tracks, 2]


### PR DESCRIPTION
Now in trajnet++, all scenes with only the primary pedestrian in the scene, will be removed. When I add these scenes, in the training step, it will have an error:   
 ```
return torch._C._nn.linear(input, weight, bias)
RuntimeError: mat1 and mat2 shapes cannot be multiplied (8x36 and 288x256)
```
Because in `trajnetbaselines/lstm/gridbased_pooling.py`,  grid, generated by `occupancy()` , the shape of grid maybe wrong in single pedestrain's case. The grid shape is `[num_tracks * batch_size, self.pooling_dim, self.n, self.n]`, like `[32,2,12,12]` but in code for only one pedestrian, the grid shape is  `[num_tracks, self.pooling_dim, self.n, self.n]`, like `[1,2,12,12]`. It should be `[8,12,12,12]` in this case. 

